### PR TITLE
Use gawk package in installer dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMPDIR=$(mktemp -d)
 umask 077
 
-APT_PACKAGES=(curl jq sed awk iproute2 tar ca-certificates logrotate systemd unzip uuid-runtime)
+APT_PACKAGES=(curl jq sed gawk iproute2 tar ca-certificates logrotate systemd unzip uuid-runtime)
 
 apt-get update
 apt-get install -y "${APT_PACKAGES[@]}"


### PR DESCRIPTION
## Summary
- replace the awk entry in the installer dependency list with the gawk package so the script requests a real APT package

## Testing
- `sudo apt-get install -y curl jq sed gawk iproute2 tar ca-certificates logrotate systemd unzip uuid-runtime` *(fails in CI environment because Ubuntu package mirrors are blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68dd78548c4883239714f46086eb9e9a